### PR TITLE
Sort deltas by name within groups

### DIFF
--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -66,11 +66,11 @@ class Upgrader:
                     d.get_version()), end=' ')
 
                 if d.get_type() in [Delta.DELTA_PRE_SQL, Delta.DELTA_SQL,
-                                  Delta.DELTA_POST_SQL]:
+                                    Delta.DELTA_POST_SQL]:
                     self.__run_delta_sql(d)
                     print('OK')
                 elif d.get_type() in [Delta.DELTA_PRE_PY, Delta.DELTA_PY,
-                                    Delta.DELTA_POST_PY]:
+                                      Delta.DELTA_POST_PY]:
                     self.__run_delta_py(d)
                     print('OK')
                 else:

--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -178,9 +178,9 @@ class Upgrader:
         filepath: str
             the path of the file to execute"""
 
-        delta_file = open(filepath, 'r')
-        self.cursor.execute(delta_file.read())
-        self.connection.commit()
+        with open(filepath, 'r') as delta_file:
+            self.cursor.execute(delta_file.read())
+            self.connection.commit()
 
     def __run_py_file(self, filepath, module_name):
         """Execute the python file at the passed path
@@ -523,7 +523,9 @@ class Delta:
 
     def get_checksum(self):
         """Return the md5 checksum of the delta file."""
-        return md5(open(self.file, 'rb').read()).hexdigest()
+        with open(self.file, 'rb') as f:
+            cs = md5(f.read()).hexdigest()
+        return cs
 
     def get_type(self):
         """Return the type of the delta file.

--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -126,7 +126,7 @@ class Upgrader:
             delta = Delta(file)
             deltas.append(delta)
 
-        return sorted(deltas, key=lambda x: (x.get_version(), x.get_type()))
+        return sorted(deltas, key=lambda x: (x.get_version(), x.get_type(), x.get_name()))
 
     def __run_delta_sql(self, delta):
         """Execute the delta sql file on the database"""

--- a/pum/test/test_upgrader.py
+++ b/pum/test/test_upgrader.py
@@ -9,9 +9,9 @@ from pum.core.upgrader import Upgrader, Delta
 
 class TestUpgrader(TestCase):
     """Test the class Upgrader.
-    
+
     1 pg_service needed for test:
-        qwat_test_1 
+        qwat_test_1
     """
 
     def setUp(self):
@@ -45,7 +45,7 @@ class TestUpgrader(TestCase):
             shutil.rmtree('/tmp/test_upgrader')
         except OSError:
             pass
-        
+
         os.mkdir('/tmp/test_upgrader/')
 
         file = open('/tmp/test_upgrader/delta_0.0.1_0.sql', 'w+')

--- a/pum/test/test_upgrader.py
+++ b/pum/test/test_upgrader.py
@@ -48,11 +48,19 @@ class TestUpgrader(TestCase):
         
         os.mkdir('/tmp/test_upgrader/')
 
-        file = open('/tmp/test_upgrader/delta_0.0.1.sql', 'w+')
+        file = open('/tmp/test_upgrader/delta_0.0.1_0.sql', 'w+')
         file.write('DROP TABLE IF EXISTS test_upgrader.bar;')
         file.write(
             'CREATE TABLE test_upgrader.bar '
             '(id smallint, value integer, name varchar(100));')
+        file.close()
+
+        file = open('/tmp/test_upgrader/delta_0.0.1_a.sql', 'w+')
+        file.write('SELECT 2;')
+        file.close()
+
+        file = open('/tmp/test_upgrader/delta_0.0.1_1.sql', 'w+')
+        file.write('SELECT 1;')
         file.close()
 
         self.upgrader = Upgrader(
@@ -65,6 +73,15 @@ class TestUpgrader(TestCase):
         self.cur1.execute(
             "SELECT to_regclass('{}');".format(self.upgrades_table))
         self.assertIsNotNone(self.cur1.fetchone()[0])
+
+        self.cur1.execute(
+            "SELECT description from {};".format(self.upgrades_table))
+        results = self.cur1.fetchall()
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0][0], 'baseline')
+        self.assertEqual(results[1][0], '0')
+        self.assertEqual(results[2][0], '1')
+        self.assertEqual(results[3][0], 'a')
 
     def test_delta_valid_name(self):
         self.assertTrue(

--- a/pum/test/test_upgrader.py
+++ b/pum/test/test_upgrader.py
@@ -48,20 +48,17 @@ class TestUpgrader(TestCase):
 
         os.mkdir('/tmp/test_upgrader/')
 
-        file = open('/tmp/test_upgrader/delta_0.0.1_0.sql', 'w+')
-        file.write('DROP TABLE IF EXISTS test_upgrader.bar;')
-        file.write(
-            'CREATE TABLE test_upgrader.bar '
-            '(id smallint, value integer, name varchar(100));')
-        file.close()
+        with open('/tmp/test_upgrader/delta_0.0.1_0.sql', 'w+') as f:
+            f.write('DROP TABLE IF EXISTS test_upgrader.bar;')
+            f.write(
+                'CREATE TABLE test_upgrader.bar '
+                '(id smallint, value integer, name varchar(100));')
 
-        file = open('/tmp/test_upgrader/delta_0.0.1_a.sql', 'w+')
-        file.write('SELECT 2;')
-        file.close()
+        with open('/tmp/test_upgrader/delta_0.0.1_a.sql', 'w+') as f:
+            f.write('SELECT 2;')
 
-        file = open('/tmp/test_upgrader/delta_0.0.1_1.sql', 'w+')
-        file.write('SELECT 1;')
-        file.close()
+        with open('/tmp/test_upgrader/delta_0.0.1_1.sql', 'w+') as f:
+            f.write('SELECT 1;')
 
         self.upgrader = Upgrader(
             pg_service1, self.upgrades_table, '/tmp/test_upgrader/')


### PR DESCRIPTION
This PR suggests sorting deltas by name within (version, type) groups.

Currently the order of deltas within a (version, type) group depends on the order of the list returned by `listdir`. And that order is system-dependent.

So this PR changes the sort key to use (version, type, name) rather than (version, type), making sure that deltas are sorted by their names within (version, type) groups.

I am happy to add tests for this, but I don't know how to run the tests a this point. See https://github.com/opengisch/pum/issues/21.