### PR TITLE
Use "str" rather "string" in docstrings

### DIFF
--- a/pum/core/checker.py
+++ b/pum/core/checker.py
@@ -16,13 +16,13 @@ class Checker:
 
         Parameters
         ----------
-        pg_service1: string
+        pg_service1: str
             The name of the postgres service (defined in pg_service.conf)
             related to the first db to be compared
-        pg_service2: string
+        pg_service2: str
             The name of the postgres service (defined in pg_service.conf)
             related to the first db to be compared
-        ignore_list: list of strings
+        ignore_list: list(str)
             List of elements to be ignored in check (ex. tables, columns,
             views, ...)
         verbose_level: int

--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -25,13 +25,13 @@ class Upgrader:
 
             Parameters
             ----------
-            pg_service: string
+            pg_service: str
                 The name of the postgres service (defined in pg_service.conf)
                 related to the db
-            upgrades_table: string
+            upgrades_table: str
                 The name of the table (int the format schema.name) where the
                 informations about the upgrades are stored
-            directory: string
+            directory: str
                 The path of the directory where the delta files are stored
         """
         self.pg_service = pg_service


### PR DESCRIPTION
`string` is not a Python type, so use `str` to specify the type of string parameters in docstrings.