### PR TITLE
Exit 1 when check or test-and-upgrade fails

### DIFF
--- a/scripts/pum
+++ b/scripts/pum
@@ -303,6 +303,11 @@ class Pum:
             views, ...)
         ignore_restore_errors: Boolean
             If true the pg_restore errors don't cause the exit of the program
+
+        Returns
+        -------
+        False if the prod database cannot be upgraded because there are
+        differences between the test and comp databases.
         """
 
         self.__out('Test and upgrade...', type='WAITING')
@@ -320,15 +325,16 @@ class Pum:
         check_result = self.run_check(
             pg_service_test, pg_service_comp, ignore_list)
 
-        if check_result:
-            if ask_for_confirmation(prompt='Apply deltas to {}?'.format(
-                    pg_service_prod)):
-                self.run_upgrade(pg_service_prod, table, delta_dir)
-        else:
-            # print error
-            pass
+        if not check_result:
+            return False
+
+        if ask_for_confirmation(prompt='Apply deltas to {}?'.format(
+                pg_service_prod)):
+            self.run_upgrade(pg_service_prod, table, delta_dir)
 
         self.__out('OK', 'OKGREEN')
+
+        return True
 
     def __out(self, message, type='DEFAULT'):
         # print output of the commands
@@ -509,8 +515,10 @@ if __name__ == "__main__":
     elif args.command == 'upgrade':
         pum.run_upgrade(args.pg_service, args.table, args.dir)
     elif args.command == 'test-and-upgrade':
-        pum.run_test_and_upgrade(
+        success = pum.run_test_and_upgrade(
             args.pg_service_prod, args.pg_service_test, args.pg_service_comp,
             args.file, args.table, args.dir, args.ignore, args.x)
+        if not success:
+            exitval = 1
 
     exit(exitval)

--- a/scripts/pum
+++ b/scripts/pum
@@ -490,11 +490,14 @@ if __name__ == "__main__":
         parser.print_help()
         parser.exit()
 
+    exitval = 0
     pum = Pum(args.config_file)
 
     if args.command == 'check':
-        pum.run_check(args.pg_service1, args.pg_service2, args.ignore,
-                      args.verbose_level, args.output_file)
+        success = pum.run_check(args.pg_service1, args.pg_service2, args.ignore,
+                                args.verbose_level, args.output_file)
+        if not success:
+            exitval = 1
     elif args.command == 'dump':
         pum.run_dump(args.pg_service, args.file)
     elif args.command == 'restore':
@@ -509,3 +512,5 @@ if __name__ == "__main__":
         pum.run_test_and_upgrade(
             args.pg_service_prod, args.pg_service_test, args.pg_service_comp,
             args.file, args.table, args.dir, args.ignore, args.x)
+
+    exit(exitval)


### PR DESCRIPTION
Currently Pum exits with the 0 exit code when the `check` subcommand detects that the databases have differences. Likewise Pum exists with the 0 exit code when the `test-and-upgrade` subcommand did not upgrade the "prod" database because the "test" and "comp" databases have differences. This PR makes the code exit 1 in both of these cases.

Related QWAT issue: https://github.com/qwat/qwat-data-model/issues/234.