### PR TITLE
Change psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML
-psycopg2>=2.7.3
+psycopg2-binary>=2.7.3

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Development Status :: 5 - Production/Stable'
     ],
     install_requires = [
-        'psycopg2>=2.7.3',
+        'psycopg2-binary>=2.7.3',
         'PyYAML'
     ],
     python_requires=">=3.3",


### PR DESCRIPTION
After a fresh installation of Pum and its dependencies the following warning is displayed when running a `pum` command:

    UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.

This commit fixes that using `psycopg2-binary` in place of `psycopg2` as the name of the Psycopg2 dependency.