### PR TITLE
Add multi delta dirs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ deltas. Only the delta files with version greater or equal than the current vers
 The usage of the command is:
 
 ```commandline
-usage: pum upgrade [-h] -p PG_SERVICE -t TABLE -d DIR
+usage: pum upgrade [-h] -p PG_SERVICE -t TABLE -d DIR [DIR ...]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -211,7 +211,8 @@ optional arguments:
                         Name of the postgres service
   -t TABLE, --table TABLE
                         Upgrades information table
-  -d DIR, --dir DIR     Set delta directory
+  -d DIR [DIR ...], --dir DIR [DIR ...]
+                        Delta directories (space-separated)
 ```
 
 ### info
@@ -220,7 +221,7 @@ The `info` command prints the status of the already or not applied delta files.
 The usage of the command is:
 
 ```commandline
-usage: pum info [-h] -p PG_SERVICE -t TABLE -d DIR
+usage: pum info [-h] -p PG_SERVICE -t TABLE -d DIR [DIR ...]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -228,7 +229,8 @@ optional arguments:
                         Name of the postgres service
   -t TABLE, --table TABLE
                         Upgrades information table
-  -d DIR, --dir DIR     Set delta directory
+  -d DIR [DIR ...], --dir DIR [DIR ...]
+                        Delta directories (space-separated)
 ```
 
 ### baseline
@@ -238,7 +240,7 @@ The `baseline` command creates the upgrades information table and sets the curre
 The usage of the command is:
 
 ```commandline
-usage: pum baseline [-h] -p PG_SERVICE -t TABLE -d DIR -b BASELINE
+usage: pum baseline [-h] -p PG_SERVICE -t TABLE -d DIR [DIR ...] -b BASELINE
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -246,7 +248,8 @@ optional arguments:
                         Name of the postgres service
   -t TABLE, --table TABLE
                         Upgrades information table
-  -d DIR, --dir DIR     Delta directory
+  -d DIR [DIR ...], --dir DIR [DIR ...]
+                        Delta directories (space-separated)
   -b BASELINE, --baseline BASELINE
                         Set baseline  in the format x.x.x
 ```
@@ -260,7 +263,7 @@ The `test-and-upgrade` command does the following steps:
 
 - creates a dump of the production db
 - restores the db dump into a test db
-- applies the delta files found in the delta directory to the test db.
+- applies the delta files found in the delta directories to the test db.
 - checks if there are differences between the test db and a comparison db
 - if no significant differences are found, after confirmation, applies the delta files to the production dbD.
 Only the delta files with version greater or equal than the current version are applied.
@@ -269,7 +272,7 @@ The usage of the command is:
 ```commandline
 usage: pum test-and-upgrade [-h] [-pp PG_SERVICE_PROD]
                             [-pt PG_SERVICE_TEST] [-pc PG_SERVICE_COMP]
-                            [-t TABLE] [-d DIR] [-f FILE]
+                            [-t TABLE] -d DIR [DIR ...] [-f FILE]
                             [-i {tables,columns,constraints,views,sequences,indexes,triggers,functions,rules}
 
 optional arguments:
@@ -284,7 +287,8 @@ optional arguments:
                         the updated db test with the last version of the db
   -t TABLE, --table TABLE
                         Upgrades information table
-  -d DIR, --dir DIR     Set delta directory
+  -d DIR [DIR ...], --dir DIR [DIR ...]
+                        Delta directories (space-separated)
   -f FILE, --file FILE  The backup file
   -x                    ignore pg_restore errors
   -i {tables,columns,constraints,views,sequences,indexes,triggers,functions,rules} ,
@@ -349,7 +353,11 @@ A Python delta file must be a subclass of the DeltaPy class. The DeltaPy class h
 
     @property
     def delta_dir(self):
-        """Return the path of the delta directory"""
+        """Return the path of the first delta directory"""
+
+    @property
+    def delta_dirs(self):
+        """Return the paths of the delta directories"""
 
     @property
     def pg_service(self):
@@ -381,8 +389,8 @@ class Prova(DeltaPy):
         # if you want to get the current db version
         version = self.current_db_version()          
 
-        # if you want to get the delta directory path
-        delta_dir = self.delta_dir()
+        # if you want to get the paths to the delta directories
+        delta_dirs = self.delta_dirs()
 
         # if you want to get the pg_service name
         pg = self.pg_service()

--- a/pum/core/deltapy.py
+++ b/pum/core/deltapy.py
@@ -7,7 +7,7 @@ class DeltaPy(metaclass=ABCMeta):
     """This abstract class must be instantiated by the delta.py classes"""
 
     def __init__(
-            self, current_db_version, delta_dir, pg_service, upgrades_table):
+            self, current_db_version, delta_dirs, pg_service, upgrades_table):
         """Constructor, receive some useful parameters accesible from the
         subclasses als propperties.
 
@@ -21,15 +21,15 @@ class DeltaPy(metaclass=ABCMeta):
         upgrades_table: str
             The name of the table (int the format schema.name) where the
             informations about the upgrades are stored
-        delta_dir: str
-            The path of the directory where the delta files are stored
+        delta_dirs: list(str)
+            The paths to directories where delta files are stored
         """
 
         self.__current_db_version = current_db_version
-        self.__delta_dir = delta_dir
+        self.__delta_dirs = delta_dirs
         self.__pg_service = pg_service
         self.__upgrades_table = upgrades_table
-        
+
     @abstractmethod
     def run(self):
         """This method must be implemented in the subclasses. It is called
@@ -43,8 +43,13 @@ class DeltaPy(metaclass=ABCMeta):
 
     @property
     def delta_dir(self):
-        """Return the path of the delta directory"""
-        return self.__delta_dir
+        """Return the path of the first delta directory"""
+        return self.__delta_dirs[0]
+
+    @property
+    def delta_dirs(self):
+        """Return the paths of the delta directories"""
+        return self.__delta_dirs
 
     @property
     def pg_service(self):

--- a/scripts/pum
+++ b/scripts/pum
@@ -18,7 +18,7 @@ class Pum:
     def __init__(self, config_file=None):
 
         self.upgrades_table = None
-        self.delta_dir = None
+        self.delta_dirs = None
         self.backup_file = None
         self.ignore_list = None
         self.pg_dump_exe = None
@@ -48,8 +48,11 @@ class Pum:
             Dictionary of configurations
             """
 
+        if not isinstance(configs['delta_dir'], list):
+            configs['delta_dir'] = [configs['delta_dir']]
+
         self.upgrades_table = configs['upgrades_table']
-        self.delta_dir = configs['delta_dir']
+        self.delta_dirs = configs['delta_dirs']
         self.backup_file = configs['backup_file']
         self.ignore_list = configs['ignore_elements']
         self.pg_dump_exe = configs['pg_dump_exe']
@@ -183,7 +186,7 @@ class Pum:
             exit(1)
         self.__out('OK', 'OKGREEN')
 
-    def run_baseline(self, pg_service, table, delta_dir, baseline):
+    def run_baseline(self, pg_service, table, delta_dirs, baseline):
         """
         Run the baseline command. Set the current database version
         (baseline) into the specified table.
@@ -196,8 +199,8 @@ class Pum:
         table: str
             The name of the upgrades information table in the format
             schema.table
-        delta_dir: str
-            The path of the delta directory
+        delta_dirs: list(str)
+            The paths to the delta directories
         baseline: str
             The version of the current database to set in the information
             table. The baseline must be in the format x.x.x where x are numbers.
@@ -207,7 +210,7 @@ class Pum:
         self.__out('Set baseline...', type='WAITING')
 
         try:
-            upgrader = Upgrader(pg_service, table, delta_dir)
+            upgrader = Upgrader(pg_service, table, delta_dirs)
             upgrader.create_upgrades_table()
             upgrader.set_baseline(baseline)
 
@@ -218,7 +221,7 @@ class Pum:
 
         self.__out('OK', 'OKGREEN')
 
-    def run_info(self, pg_service, table, delta_dir):
+    def run_info(self, pg_service, table, delta_dirs):
         """Print info about delta file and about already made upgrade
 
         Parameters
@@ -229,19 +232,19 @@ class Pum:
         table: str
             The name of the upgrades information table in the format
             schema.table
-        delta_dir: str
-            The path of the delta directory
+        delta_dir: list(str)
+            The paths to the delta directories
         """
 
         try:
-            upgrader = Upgrader(pg_service, table, delta_dir)
+            upgrader = Upgrader(pg_service, table, delta_dirs)
             upgrader.show_info()
 
         except Exception as e:
             print(e)
             exit(1)
 
-    def run_upgrade(self, pg_service, table, delta_dir):
+    def run_upgrade(self, pg_service, table, delta_dirs):
         """Apply the delta files to upgrade the database
 
         Parameters
@@ -251,14 +254,14 @@ class Pum:
         table: str
             The name of the upgrades information table in the format
             schema.table
-        delta_dir: str
-            The path of the delta directory
+        delta_dirs: list(str)
+            The paths to the delta directories
         """
 
         self.__out('Upgrade...', type='WAITING')
 
         try:
-            upgrader = Upgrader(pg_service, table, delta_dir)
+            upgrader = Upgrader(pg_service, table, delta_dirs)
             upgrader.run()
 
         except Exception as e:
@@ -269,7 +272,7 @@ class Pum:
 
     def run_test_and_upgrade(
             self, pg_service_prod, pg_service_test, pg_service_comp, file,
-            table, delta_dir, ignore_list, ignore_restore_errors=False):
+            table, delta_dirs, ignore_list, ignore_restore_errors=False):
         """
         Do the following steps:
             - creates a dump of the production db
@@ -296,8 +299,8 @@ class Pum:
         table: str
             The name of the upgrades information table in the format
             schema.table
-        delta_dir: str
-            The path of the delta directory
+        delta_dirs: list(str)
+            The paths to the delta directories
         ignore_list: list of strings
             List of elements to be ignored in check (ex. tables, columns,
             views, ...)
@@ -319,7 +322,7 @@ class Pum:
         self.run_restore(pg_service_test, file, ignore_restore_errors)
 
         # Apply deltas on db test
-        self.run_upgrade(pg_service_test, table, delta_dir)
+        self.run_upgrade(pg_service_test, table, delta_dirs)
 
         # Compare db test with db comp
         check_result = self.run_check(
@@ -330,7 +333,7 @@ class Pum:
 
         if ask_for_confirmation(prompt='Apply deltas to {}?'.format(
                 pg_service_prod)):
-            self.run_upgrade(pg_service_prod, table, delta_dir)
+            self.run_upgrade(pg_service_prod, table, delta_dirs)
 
         self.__out('OK', 'OKGREEN')
 
@@ -424,7 +427,8 @@ if __name__ == "__main__":
     parser_baseline.add_argument(
         '-t', '--table', help='Upgrades information table', required=True)
     parser_baseline.add_argument(
-        '-d', '--dir', help='Delta directory', required=True)
+        '-d', '--dir', nargs='+', help='Delta directories (space-separated)',
+        required=True)
     parser_baseline.add_argument(
         '-b', '--baseline', help='Set baseline in the format x.x.x',
         required=True)
@@ -437,7 +441,8 @@ if __name__ == "__main__":
     parser_info.add_argument(
         '-t', '--table', help='Upgrades information table', required=True)
     parser_info.add_argument(
-        '-d', '--dir', help='Set delta directory', required=True)
+        '-d', '--dir', nargs='+', help='Delta directories (space-separated)',
+        required=True)
 
     # create the parser for the "upgrade" command
     parser_upgrade = subparsers.add_parser('upgrade', help='upgrade db')
@@ -447,7 +452,8 @@ if __name__ == "__main__":
     parser_upgrade.add_argument(
         '-t', '--table', help='Upgrades information table', required=True)
     parser_upgrade.add_argument(
-        '-d', '--dir', help='Set delta directory', required=True)
+        '-d', '--dir', nargs='+', help='Delta directories (space-separated)',
+        required=True)
 
     # create the parser for the "test-and-upgrade" command
     parser_test_and_upgrade = subparsers.add_parser(
@@ -468,7 +474,8 @@ if __name__ == "__main__":
     parser_test_and_upgrade.add_argument(
         '-t', '--table', help='Upgrades information table')
     parser_test_and_upgrade.add_argument(
-        '-d', '--dir', help='Set delta directory')
+        '-d', '--dir', nargs='+', help='Delta directories (space-separated)',
+        required=True)
     parser_test_and_upgrade.add_argument('-f', '--file', help='The backup file')
     parser_test_and_upgrade.add_argument(
         '-x', help='ignore pg_restore errors', action="store_true")


### PR DESCRIPTION
This PR adds support for multiple delta directories. This is for example useful for handling database extensions with separate delta directories.

So with the proposed changes in this PR one can do:

```shell
$ pum upgrade -p my_service -t public.pum_upgrades -d /path/to/deltas1 /path/to/deltas2
```

The changes are backward-compatible, meaning that existing scripts that use Pum won't need to be updated.

Other things to note:

For backward-compatibility reasons I decided to keep the `DeltaPy:delta_dir` property. It refers to the first delta directory provided on the command line. And I introduced `DeltaPy:delta_dirs` to get the list of delta directories.

Deltas are applied in directory order. For example if you use `-d deltas1 deltas2` on the command line Pum guarantees that the deltas in `deltas1` will be applied before the deltas in `deltas2`. And within directories deltas are ordered as before, that is using (version, type, name) as the sort key.

I updated the docs (README) and the unit tests.

I also tested this in QWAT. For that I [changed](https://github.com/qwat/qwat-data-model/compare/master...elemoine:ele_pum-deltas) QWAT's Travis script to pass an extra delta directory to the `pum test-and-upgrade` command. I will propose this in a QWAT PR when this Pum PR is merged and a new Pum version is released on pypi.

Please review.