### PR TITLE
Change DeltaPy.delta_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,26 +387,25 @@ class Prova(DeltaPy):
     def run(self):
 
         # if you want to get the current db version
-        version = self.current_db_version()          
+        version = self.current_db_version
 
         # if you want to get the path to the delta directory including that delta file
-        delta_dir = self.delta_dir()
+        delta_dir = self.delta_dir
 
         # if you want to get the paths to the delta directories
-        delta_dirs = self.delta_dirs()
+        delta_dirs = self.delta_dirs
 
         # if you want to get the pg_service name
-        pg = self.pg_service()
+        pg = self.pg_service
 
         # if you want to get the upgrade information table name
-        table = self.upgrades_table()
+        table = self.upgrades_table
 
         # if you want to print a message
         self.write_message('foo')
 
         # Here goes all the code of the delta file
         some_cool_python_command()
-
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ A Python delta file must be a subclass of the DeltaPy class. The DeltaPy class h
 
     @property
     def delta_dir(self):
-        """Return the path of the first delta directory"""
+        """Return the path of the delta directory including this delta"""
 
     @property
     def delta_dirs(self):
@@ -388,6 +388,9 @@ class Prova(DeltaPy):
 
         # if you want to get the current db version
         version = self.current_db_version()          
+
+        # if you want to get the path to the delta directory including that delta file
+        delta_dir = self.delta_dir()
 
         # if you want to get the paths to the delta directories
         delta_dirs = self.delta_dirs()

--- a/pum/core/deltapy.py
+++ b/pum/core/deltapy.py
@@ -7,7 +7,7 @@ class DeltaPy(metaclass=ABCMeta):
     """This abstract class must be instantiated by the delta.py classes"""
 
     def __init__(
-            self, current_db_version, delta_dirs, pg_service, upgrades_table):
+            self, current_db_version, delta_dir, delta_dirs, pg_service, upgrades_table):
         """Constructor, receive some useful parameters accesible from the
         subclasses als propperties.
 
@@ -21,11 +21,14 @@ class DeltaPy(metaclass=ABCMeta):
         upgrades_table: str
             The name of the table (int the format schema.name) where the
             informations about the upgrades are stored
+        delta_dir: str
+            The path to the directory where this delta file is stored
         delta_dirs: list(str)
             The paths to directories where delta files are stored
         """
 
         self.__current_db_version = current_db_version
+        self.__delta_dir = delta_dir
         self.__delta_dirs = delta_dirs
         self.__pg_service = pg_service
         self.__upgrades_table = upgrades_table
@@ -43,8 +46,8 @@ class DeltaPy(metaclass=ABCMeta):
 
     @property
     def delta_dir(self):
-        """Return the path of the first delta directory"""
-        return self.__delta_dirs[0]
+        """Return the path of the delta directory including this delta"""
+        return self.__delta_dir
 
     @property
     def delta_dirs(self):


### PR DESCRIPTION
Instead of having DeltaPy.delta_dir return the first delta dir in the list let's return the delta_dir into which the delta file is actually stored. This is much more useful to DeltaPy subclasses.

The change is backward-compatible, and I've verified that the tests still pass.