### PR TITLE
Fix regressions in check test-and-upgrade commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ optional arguments:
   -i {tables,columns,constraints,views,sequences,indexes,triggers,functions,rules}, --ignore {tables,columns,constraints,views,sequences,indexes,triggers,functions,rules}
                         Elements to be ignored
   -s SCHEMA [SCHEMA...], --skip-schemas SCHEMA [SCHEMA...]
-                        Schemas to be skpipped.
+                        Schemas to be skipped.
   -v VERBOSE_LEVEL, --verbose_level VERBOSE_LEVEL
                         Verbose level (0, 1 or 2)
   -o OUTPUT_FILE, --output_file OUTPUT_FILE

--- a/scripts/pum
+++ b/scripts/pum
@@ -334,7 +334,7 @@ class Pum:
 
         # Compare db test with db comp
         check_result = self.run_check(
-            pg_service_test, pg_service_comp, skip_schemas, ignore_list )
+            pg_service_test, pg_service_comp, ignore_list, skip_schemas)
 
         if not check_result:
             return False

--- a/scripts/pum
+++ b/scripts/pum
@@ -96,7 +96,7 @@ class Pum:
         try:
             checker = Checker(
                 pg_service1, pg_service2,
-                ignore_list, skip_schemas, verbose_level)
+                skip_schemas, ignore_list, verbose_level)
             result, differences = checker.run_checks()
 
             if result:

--- a/scripts/pum
+++ b/scripts/pum
@@ -59,7 +59,7 @@ class Pum:
         self.pg_restore_exe = configs['pg_restore_exe']
 
     def run_check(self, pg_service1, pg_service2, ignore_list=None,
-                  skip_schemas=None,verbose_level=1, output_file=None):
+                  skip_schemas=None, verbose_level=1, output_file=None):
         """Run the check command
 
         Parameters
@@ -504,7 +504,6 @@ if __name__ == "__main__":
                  'rules'])
     parser_test_and_upgrade.add_argument(
         '-s', '--skip-schemas', help='Schemas to be ignored.', nargs='+')
-
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This fixes a regression in the `test-and-upgrade` command, where `run_check` was called with the `ignore_list` and `skip_schemas` arguments in the reverse order.

I also added commits fixing pep8 in a typo in the README file.