### PR TITLE
correct min Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
-if sys.version_info < (3,3):
-    sys.exit('Pum requires at least Python version 3.3.\nYou are currently running this installation with\n\n{}'.format(sys.version))
+if sys.version_info < (3,6):
+    sys.exit('Pum requires at least Python version 3.6.\nYou are currently running this installation with\n\n{}'.format(sys.version))
 
 setup(
     name = 'pum',


### PR DESCRIPTION
since merge of #50, it uses [enum.IntFlag,](https://docs.python.org/3/library/enum.html#enum.IntFlag) introduced in Python 3.6
this sounds an acceptable number to me, the worst is that we drop Ubuntu 16.04 (Xenial) support, but hey, it's 3 years old, and there is a new LTS since. Also Travis supports higher version of Python on Xenial.