### PR TITLE
Add more constraints to the upgrades table

### DIFF
--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -410,7 +410,7 @@ class Upgrader:
         query = """CREATE TABLE IF NOT EXISTS {}
                 (
                 id serial NOT NULL,
-                version character varying(50),
+                version character varying(50) NOT NULL,
                 description character varying(200) NOT NULL,
                 type integer NOT NULL,
                 script character varying(1000) NOT NULL,

--- a/pum/core/upgrader.py
+++ b/pum/core/upgrader.py
@@ -419,7 +419,8 @@ class Upgrader:
                 installed_on timestamp without time zone NOT NULL DEFAULT now(),
                 execution_time integer NOT NULL,
                 success boolean NOT NULL,
-                PRIMARY KEY (id)
+                PRIMARY KEY (id),
+                EXCLUDE (version WITH =) WHERE (type = 0)
                 )
         """.format(self.upgrades_table)
 


### PR DESCRIPTION
The current constraints on the upgrades table do not prevent inserting multiple baseline entries with the same version. For example I can execute `pum baseline -b 1.0.0` twice and I'll end up with two baseline entries with the 1.0.0 version. Although this may not cause any problem it may be confusing to someone looking at the content of the upgrades table.

This PR suggests adding an EXCLUDE constraint preventing this from happening. When attempting to inserting a baseline entry with a version that already exists in the table an ExclusionViolation error will be raised.

For example:

```shell
$ pum baseline -p pum_test -t pum_info -d deltas -b 1.0.0
Set baseline...OK
$ pum baseline -p pum_test -t pum_info -d deltas -b 1.0.0
Set baseline...Traceback (most recent call last):
  File "/home/elemoine/.virtualenvs/pum/bin/pum", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/elemoine/src/pum/scripts/pum", line 575, in <module>
    pum.run_baseline(args.pg_service, args.table, args.dir, args.baseline)
  File "/home/elemoine/src/pum/scripts/pum", line 220, in run_baseline
    upgrader.set_baseline(baseline)
  File "/home/elemoine/src/pum/pum/core/upgrader.py", line 462, in set_baseline
    self.cursor.execute(query)
psycopg2.errors.ExclusionViolation: conflicting key value violates exclusion constraint "pum_info_version_excl"                                                                               
DETAIL:  Key (version)=(1.0.0) conflicts with existing key (version)=(1.0.0).
```

What do you think?