### PR TITLE
Remove the DeltaPy.variable methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,33 +377,6 @@ A Python delta file must be a subclass of the DeltaPy class. The DeltaPy class h
     def variables(self):
         """Return the dictionary of variables"""
         
-    def variable(self, name: str):
-        """
-        Returns the value of the variable given in PUM
-
-        Parameters
-        ----------
-        name
-            the name of the variable
-
-        Raises
-        ------
-        KeyError
-            if the variable is not found.
-        """
-
-    def variable(self, name: str, default_value=None):
-        """
-        Safely returns the value of the variable given in PUM
-
-        Parameters
-        ----------
-        name
-            the name of the variable
-        default_value
-            the default value for the variable if it does not exist
-        """
-
     @property
     def current_db_version(self):
         """Return the current db version"""
@@ -459,7 +432,7 @@ class Prova(DeltaPy):
         table = self.upgrades_table
         
         # access to a variable given in command line
-        srid = self.variable('my_var_name')
+        srid = self.variables.get('srid', 4326)
 
         # if you want to print a message
         self.write_message('foo')

--- a/pum/core/deltapy.py
+++ b/pum/core/deltapy.py
@@ -47,45 +47,6 @@ class DeltaPy(metaclass=ABCMeta):
         """Return the dictionary of variables"""
         return self.__variables
 
-    def variable(self, name: str):
-        """
-        Returns the value of the variable given in PUM
-
-        Parameters
-        ----------
-        name: str
-            the name of the variable
-
-        Raises
-        ------
-        KeyError
-            if the variable is not found
-
-        Returns
-        -------
-        str or int or float
-            The variable value
-        """
-        return self.__variables[name]
-
-    def variable(self, name: str, default_value=None):
-        """
-        Safely returns the value of the variable given in PUM
-
-        Parameters
-        ----------
-        name: str
-            the name of the variable
-        default_value: str or int or float
-            the default value for the variable if it does not exist
-
-        Returns
-        -------
-        str or int or float
-            The variable value
-        """
-        return self.__variables.get(name, default_value)
-
     @property
     def current_db_version(self):
         """Return the current db version"""

--- a/test/data/delta/delta_1.1.0_delta_with_param.py
+++ b/test/data/delta/delta_1.1.0_delta_with_param.py
@@ -7,7 +7,7 @@ from pum.core.deltapy import DeltaPy
 class CreateViews(DeltaPy):
 
     def run(self):
-        my_field_length = self.variable('my_field_length')
+        my_field_length = self.variables['my_field_length']
 
         conn = psycopg2.connect("service={0}".format(self.pg_service))
         cursor = conn.cursor()


### PR DESCRIPTION
This PR suggests to remove the `DeltaPy.variable` methods. To access a variable from a child class one can just use the `self.variables` dict. I don't think there's a need for more abstraction here.

I also added a commit to rely on psycopg2 to pass parameters to the SQL query in the delta_1.1.0_delta_with_param.py delta file in the tests.

Relies on #59, which should be merged first.

Fixes #60.