### PR TITLE
make trigger order deterministic

### DIFF
--- a/pum/core/checker.py
+++ b/pum/core/checker.py
@@ -311,7 +311,7 @@ class Checker:
             and  SUBSTR(p.relname, 1, 3) != 'vw_'
             -- We cannot check for vw_ views,
             -- because they are created after that script
-        ORDER BY p.relname, /*t.tgname, */pp.prosrc"""
+        ORDER BY p.relname, t.tgname, pp.prosrc"""
 
         return self.__check_equals(query)
 


### PR DESCRIPTION
Triggers were not properly sorted, leading to unexpected and indeterministic check failures.

This probably only lead to issues since 08c3c1c1ad1b536e5cfe953e9c85c53bbeb946d0 because before that some triggers were not shown at all.