### PR TITLE
fix parameter-less function differences not detected

### DIFF
--- a/pum/core/checker.py
+++ b/pum/core/checker.py
@@ -327,13 +327,14 @@ class Checker:
                 A list with the differences
         """
         query = """
-        SELECT routines.routine_name, parameters.data_type,
+        SELECT routines.routine_schema, routines.routine_name, parameters.data_type,
             routines.routine_definition
         FROM information_schema.routines
-        JOIN information_schema.parameters
+        LEFT JOIN information_schema.parameters
         ON routines.specific_name=parameters.specific_name
         WHERE routines.specific_schema NOT IN {}
             AND routines.specific_schema NOT LIKE 'pg\_%'
+            AND routines.specific_schema <> 'information_schema'
         ORDER BY routines.routine_name, parameters.data_type,
             routines.routine_definition, parameters.ordinal_position
             """.format(self.exclude_schema)

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -222,6 +222,10 @@ class TestChecker(unittest.TestCase):
         self.conn1.commit()
         self.cur2.execute('DROP FUNCTION IF EXISTS add(integer, integer);')
         self.conn2.commit()
+        self.cur1.execute('DROP FUNCTION IF EXISTS nop();')
+        self.conn1.commit()
+        self.cur2.execute('DROP FUNCTION IF EXISTS nop();')
+        self.conn2.commit()
 
         result, differences = self.checker.check_functions()
         self.assertTrue(result)
@@ -255,7 +259,7 @@ class TestChecker(unittest.TestCase):
             LANGUAGE SQL
             IMMUTABLE
             RETURNS NULL ON NULL INPUT;""")
-        self.conn2.commit()
+        self.conn1.commit()
 
         result, differences = self.checker.check_functions()
         self.assertFalse(result)
@@ -270,8 +274,6 @@ class TestChecker(unittest.TestCase):
 
         result, differences = self.checker.check_functions()
         self.assertTrue(result)
-
-
 
     def test_check_rules(self):
         self.cur1.execute('DROP RULE IF EXISTS foorule ON schema_foo.bar;')

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -249,6 +249,30 @@ class TestChecker(unittest.TestCase):
         result, differences = self.checker.check_functions()
         self.assertTrue(result)
 
+        self.cur1.execute(
+            """CREATE FUNCTION nop() RETURNS integer
+            AS 'select 0;'
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;""")
+        self.conn2.commit()
+
+        result, differences = self.checker.check_functions()
+        self.assertFalse(result)
+
+        self.cur2.execute(
+            """CREATE FUNCTION nop() RETURNS integer
+            AS 'select 0;'
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;""")
+        self.conn2.commit()
+
+        result, differences = self.checker.check_functions()
+        self.assertTrue(result)
+
+
+
     def test_check_rules(self):
         self.cur1.execute('DROP RULE IF EXISTS foorule ON schema_foo.bar;')
         self.conn1.commit()


### PR DESCRIPTION
Seems parameter-less functions differences are not detected by pum check.

Failing test for now (for CI), actual fix incoming.

