### PR TITLE
fix windows CI

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -53,6 +53,8 @@ jobs:
 
       # see https://github.community/t5/GitHub-Actions/Append-PATH-on-Windows/m-p/42873/highlight/true#M5155
       - name: Add psql/bin path
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         run: echo "##[add-path].\pgsql\bin"
 
       - name: Setup db


### PR DESCRIPTION
Fixes github workflow error
```
Error: Unable to process command '##[add-path].\pgsql\bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```