### PR TITLE
fix : do not ignore trigger on views

### DIFF
--- a/pum/core/checker.py
+++ b/pum/core/checker.py
@@ -308,9 +308,6 @@ class Checker:
             and t.tgname = tl.tgname
             AND t.tgrelid = p.oid
             AND NOT tl.tgisinternal
-            and  SUBSTR(p.relname, 1, 3) != 'vw_'
-            -- We cannot check for vw_ views,
-            -- because they are created after that script
         ORDER BY p.relname, t.tgname, pp.prosrc"""
 
         return self.__check_equals(query)


### PR DESCRIPTION
Triggers on views (well, on relations that start with `vw_`) are explicitly removed from comparison compared, which could hide some inconsistencies.

I don't think the rationale (`We cannot check for vw_ views because they are created after that script`) holds, as pum check typically runs after migrations, which includes post-all and thus views ? Or do I get something wrong ?
