### PR TITLE
Fix fallback version check if multiple dist-info folders available

### DIFF
--- a/pum/pum_config.py
+++ b/pum/pum_config.py
@@ -25,7 +25,7 @@ try:
 except importlib.metadata.PackageNotFoundError:
     # Fallback: try to read from pum-*.dist-info/METADATA
     dist_info_dirs = glob.glob(os.path.join(os.path.dirname(__file__), "..", "pum-*.dist-info"))
-    version = None
+    versions = []
     for dist_info in dist_info_dirs:
         metadata_path = os.path.join(dist_info, "METADATA")
         if os.path.isfile(metadata_path):
@@ -33,11 +33,11 @@ except importlib.metadata.PackageNotFoundError:
                 for line in f:
                     if line.startswith("Version:"):
                         version = line.split(":", 1)[1].strip()
+                        versions.append(version)
                         break
-        if version:
-            break
-    if version:
-        PUM_VERSION = packaging.version.Version(version)
+    if versions:
+        # Pick the highest version
+        PUM_VERSION = max((packaging.version.Version(v) for v in versions))
     else:
         PUM_VERSION = packaging.version.Version("0.0.0")
 


### PR DESCRIPTION
Possible lib folder structure:
```
pum
pum-0.0.1.dist-info
pum-1.1.3.dist-info
```