### PR TITLE
Make migration table name dynamic

### DIFF
--- a/pum/config_model.py
+++ b/pum/config_model.py
@@ -73,6 +73,7 @@ class PumModel(PumCustomBaseModel):
 
     Attributes:
         migration_table_schema: Name of schema for the migration table.
+        migration_table_name: Name of the migration table.
         minimum_version: Minimum required version of PUM.
     """
 
@@ -80,7 +81,9 @@ class PumModel(PumCustomBaseModel):
     migration_table_schema: Optional[str] = Field(
         default="public", description="Name of schema for the migration table"
     )
-
+    migration_table_name: Optional[str] = Field(
+        default="pum_migrations", description="Name of the migration table"
+    )
     minimum_version: Optional[packaging.version.Version] = Field(
         default=None,
         description="Minimum required version of pum.",

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -51,13 +51,14 @@ class SchemaMigrations:
         SELECT EXISTS (
             SELECT 1
             FROM information_schema.tables
-            WHERE table_name = 'pum_migrations' AND table_schema = {schema}
+            WHERE table_name = {migration_table} AND table_schema = {schema}
         );
         """
         )
 
         parameters = {
             "schema": psycopg.sql.Literal(self.config.config.pum.migration_table_schema),
+            "migration_table": psycopg.sql.Literal(self.config.config.pum.migration_table_name),
         }
 
         cursor = SqlContent(query).execute(connection, parameters=parameters)

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -32,7 +32,7 @@ class SchemaMigrations:
         self.migration_table_identifier = psycopg.sql.SQL(".").join(
             [
                 psycopg.sql.Identifier(self.config.config.pum.migration_table_schema),
-                psycopg.sql.Identifier({config.config.pum.migration_table_name}),
+                psycopg.sql.Identifier(self.config.config.pum.migration_table_name),
             ]
         )
 

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -78,7 +78,7 @@ class SchemaMigrations:
             """
             SELECT table_schema
             FROM information_schema.tables
-            WHERE table_name = '{migration_table_name}' AND table_schema != {schema}
+            WHERE table_name = {migration_table_name} AND table_schema != {schema}
         """
         )
 

--- a/pum/upgrader.py
+++ b/pum/upgrader.py
@@ -79,7 +79,7 @@ class Upgrader:
         """
         if self.schema_migrations.exists(connection):
             msg = (
-                f"Schema migrations table {self.config.config.pum.migration_table_schema}.pum_migrations already exists. "
+                f"Schema migrations table {self.config.config.pum.migration_table_schema}.{self.config.config.pum.migration_table_name} already exists. "
                 "This means that the module is already installed or the database is not empty. "
                 "Use upgrade() to upgrade the db or start with a clean db."
             )
@@ -115,8 +115,9 @@ class Upgrader:
             post_hook.execute(connection=connection, commit=False, parameters=parameters)
 
         logger.info(
-            "Installed %s.pum_migrations table and applied changelogs up to version %s",
+            "Installed %s.%s table and applied changelogs up to version %s",
             self.config.config.pum.migration_table_schema,
+            self.config.config.pum.migration_table_name,
             last_changelog.version,
         )
 


### PR DESCRIPTION
This PR makes the migration table name dynamic, which is beneficial in cases where there already exists a a static sys schema, but multiple submodels need to be managed