### PR TITLE
Add skip_baseline_check parameter to upgrade()

### DIFF
--- a/pum/upgrader.py
+++ b/pum/upgrader.py
@@ -300,6 +300,7 @@ class Upgrader:
         skip_create_app: bool = False,
         roles: bool = False,
         grant: bool = False,
+        skip_baseline_check: bool = False,
         feedback: Feedback | None = None,
     ) -> None:
         """Upgrades the given module
@@ -326,6 +327,11 @@ class Upgrader:
                 If True, roles will be created.
             grant:
                 If True, permissions will be granted to the roles.
+            skip_baseline_check:
+                If True, changelogs at or below the baseline version are simply
+                skipped without verifying that each one was individually applied.
+                This is useful after restoring a database dump and using
+                ``set_baseline`` to record the current version.
             feedback:
                 A Feedback instance to report progress and check for cancellation.
                 If None, a LogFeedback instance will be used.
@@ -373,14 +379,15 @@ class Upgrader:
 
         # First pass: determine applicable changelogs
         applicable_changelogs = []
+        baseline = self.schema_migrations.baseline(connection)
         for changelog in changelogs:
-            if changelog.version <= self.schema_migrations.baseline(connection):
-                if not changelog.is_applied(
+            if changelog.version <= baseline:
+                if not skip_baseline_check and not changelog.is_applied(
                     connection=connection, schema_migrations=self.schema_migrations
                 ):
                     msg = (
                         f"Changelog version {changelog.version} is lower than or equal to the current version "
-                        f"{self.schema_migrations.baseline(connection)} but not applied. "
+                        f"{baseline} but not applied. "
                         "This indicates a problem with the database state."
                     )
                     logger.error(msg)

--- a/test/data/skip_baseline_check/changelogs/0.1.0/init.sql
+++ b/test/data/skip_baseline_check/changelogs/0.1.0/init.sql
@@ -1,0 +1,6 @@
+CREATE SCHEMA IF NOT EXISTS pum_test_data;
+
+CREATE TABLE pum_test_data.baseline_test (
+    id INT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);

--- a/test/data/skip_baseline_check/changelogs/0.2.0/update.sql
+++ b/test/data/skip_baseline_check/changelogs/0.2.0/update.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pum_test_data.baseline_test ADD COLUMN description TEXT;

--- a/test/data/skip_baseline_check/changelogs/0.3.0/update.sql
+++ b/test/data/skip_baseline_check/changelogs/0.3.0/update.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pum_test_data.baseline_test ADD COLUMN is_active BOOLEAN DEFAULT TRUE;

--- a/test/test_upgrader.py
+++ b/test/test_upgrader.py
@@ -705,6 +705,53 @@ class TestUpgrader(unittest.TestCase):
                 },
             )
 
+    def test_upgrade_skip_baseline_check(self) -> None:
+        """Test that upgrade with skip_baseline_check=True works after set_baseline."""
+        test_dir = Path("test") / "data" / "skip_baseline_check"
+        cfg = PumConfig(test_dir, pum={"module": "test_skip_baseline"})
+        sm = SchemaMigrations(cfg)
+
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            # Manually create the migration table and set a baseline at 0.2.0
+            # without installing (so no individual changelog records exist).
+            sm.create(conn, commit=False)
+
+            # Apply 0.1.0 and 0.2.0 SQL manually so the schema exists for 0.3.0.
+            cur = conn.cursor()
+            cur.execute("CREATE SCHEMA IF NOT EXISTS pum_test_data;")
+            cur.execute(
+                "CREATE TABLE pum_test_data.baseline_test ("
+                "id INT PRIMARY KEY, name VARCHAR(100) NOT NULL);"
+            )
+            cur.execute("ALTER TABLE pum_test_data.baseline_test ADD COLUMN description TEXT;")
+
+            sm.set_baseline(conn, "0.2.0", commit=False)
+            conn.commit()
+
+        # Verify upgrade() fails by default (missing individual records).
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            upgrader = Upgrader(config=cfg)
+            with self.assertRaises(PumException) as ctx:
+                upgrader.upgrade(connection=conn)
+            self.assertIn("not applied", str(ctx.exception))
+
+        # Verify upgrade(skip_baseline_check=True) succeeds and applies only 0.3.0.
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            upgrader = Upgrader(config=cfg)
+            upgrader.upgrade(connection=conn, skip_baseline_check=True)
+            conn.commit()
+
+            self.assertEqual(sm.baseline(conn), Version("0.3.0"))
+
+            # Confirm that the 0.3.0 column was actually applied.
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'pum_test_data' AND table_name = 'baseline_test' "
+                "AND column_name = 'is_active';"
+            )
+            self.assertEqual(cur.fetchone()[0], "is_active")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a database is restored from a dump and set_baseline is used to record the current version, individual changelog records don't exist in pum_migrations. The existing upgrade() check raises an error in this case.

Add skip_baseline_check=False parameter: when True, changelogs at or below the baseline are simply skipped without verifying individual application records. Default preserves backward compatibility.

Also cache the baseline() call to avoid redundant DB queries in the loop.