### PR TITLE
limit parameter input by regex

### DIFF
--- a/pum/cli.py
+++ b/pum/cli.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 import psycopg
 
@@ -20,6 +21,7 @@ from .parameter import ParameterType
 from .schema_migrations import SchemaMigrations
 from .dumper import DumpFormat, Dumper
 from .role_manager import RoleInventory, RoleManager
+from .text_processor import TextProcessor, TextValidationError
 from . import SQL
 
 
@@ -624,36 +626,22 @@ def cli() -> int:  # noqa: PLR0912
 
         # Build parameters dict for install and upgrade commands
         # Start with config-declared defaults, then override with CLI-provided values
+
         parameters = {}
         if args.command in ("install", "upgrade", "uninstall", "app"):
-            for param_def in config.parameters():
-                parameters[param_def.name] = param_def.default
-            for p in args.parameter or ():
-                param = config.parameter(p[0])
-                if not param:
-                    logger.error(f"Unknown parameter: {p[0]}")
-                    sys.exit(1)
-                if param.type == ParameterType.DECIMAL:
-                    parameters[p[0]] = float(p[1])
-                elif param.type == ParameterType.INTEGER:
-                    parameters[p[0]] = int(p[1])
-                elif param.type == ParameterType.BOOLEAN:
-                    parameters[p[0]] = p[1].lower() in ("true", "1", "yes")
-                elif param.type == ParameterType.TEXT:
-                    parameters[p[0]] = p[1]
-                elif param.type == ParameterType.PATH:
-                    parameters[p[0]] = p[1]
-                else:
-                    raise ValueError(f"Unsupported parameter type for {p[0]}: {param.type}")
-                if param.values and parameters[p[0]] not in param.values:
-                    logger.error(
-                        f"Parameter '{p[0]}' value '{parameters[p[0]]}' is not allowed. "
-                        f"Allowed values: {param.values}"
-                    )
-                    sys.exit(1)
-            logger.debug(f"Parameters: {parameters}")
+            try:
+                parameters = build_parameters_for_command(logger, config, args)
+            except TextValidationError as exc:
+                logger.error("%s", exc)
+                sys.exit(1)
+            except ValueError as exc:
+                logger.error("%s", exc)
+                sys.exit(1)
+
+            logger.debug("Parameters: %s", parameters)
 
         exit_code = 0
+
 
         if args.command == "info":
             run_info(connection=conn, config=config)
@@ -848,6 +836,57 @@ def cli() -> int:  # noqa: PLR0912
             exit_code = 1
 
     return exit_code
+
+
+
+def _cast_parameter_value(param, raw: str) -> Any:
+    if param.type == ParameterType.DECIMAL:
+        return float(raw)
+    if param.type == ParameterType.INTEGER:
+        return int(raw)
+    if param.type == ParameterType.BOOLEAN:
+        return raw.lower() in ("true", "1", "yes")
+    if param.type in (ParameterType.TEXT, ParameterType.PATH):
+        return raw
+
+    raise ValueError(f"Unsupported parameter type for {param.name}: {param.type}")
+
+
+def _validate_parameter_value(param, value: Any) -> None:
+    if param.values and value not in param.values:
+        raise ValueError(
+            f"Parameter '{param.name}' value '{value}' is not allowed. Allowed values: {param.values}"
+        )
+
+    if param.regex and param.type == ParameterType.TEXT and value is not None:
+        processor = TextProcessor(parameter=param)
+        processor.validate(str(value))
+
+
+def build_parameters_for_command(config, args) -> dict[str, Any]:
+    """
+    Generic parameter builder:
+      - starts with defaults from config definitions
+      - overrides with provided values
+      - enforces runtime constraints (values, regex)
+    """
+    parameters: dict[str, Any] = {}
+
+    for param_def in config.parameters():
+        parameters[param_def.name] = param_def.default
+
+    for p in args.parameter or ():
+        name, raw = p[0], p[1]
+        param = config.parameter(name)
+        if not param:
+            raise ValueError(f"Unknown parameter: {name}")
+
+        cast_value = _cast_parameter_value(param, raw)
+        _validate_parameter_value(param, cast_value)
+        parameters[name] = cast_value
+
+    return parameters
+
 
 
 def _print_roles_inventory(result: RoleInventory) -> None:

--- a/pum/config_model.py
+++ b/pum/config_model.py
@@ -1,6 +1,7 @@
 from packaging.version import Version
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing import Any, Literal
+import re
 
 
 from .exceptions import PumConfigError
@@ -34,6 +35,7 @@ class ParameterDefinitionModel(PumCustomBaseModel):
     app_only: bool = Field(
         default=False, description="If True, the parameter can be adapted when recreating the app."
     )
+    regex: str | None = None
 
     @model_validator(mode="before")
     def validate_default(cls, values):

--- a/pum/parameter.py
+++ b/pum/parameter.py
@@ -42,6 +42,7 @@ class ParameterDefinition:
         description: str | None = None,
         values: list | None = None,
         app_only: bool = False,
+        regex: str | None = None,
     ) -> None:
         """Initialize a ParameterDefintion instance.
 
@@ -54,6 +55,7 @@ class ParameterDefinition:
             app_only: If True, the parameter can be changed when recreating the app.
                 Standard parameters (app_only=False) must remain the same across
                 the whole application lifecycle. Defaults to False.
+            regex: regular expression used to limit text inputs
 
         Raises:
             ValueError: If type is a string and not a valid ParameterType.
@@ -74,6 +76,7 @@ class ParameterDefinition:
         self.description = description
         self.values = values
         self.app_only = app_only
+        self.regex =regex
 
     def __repr__(self) -> str:
         """Return a string representation of the ParameterDefinition instance."""
@@ -90,4 +93,5 @@ class ParameterDefinition:
             and self.description == other.description
             and self.values == other.values
             and self.app_only == other.app_only
+            and self.regex == other.regex
         )

--- a/pum/text_processor.py
+++ b/pum/text_processor.py
@@ -1,0 +1,86 @@
+import logging
+import re
+from typing import Any, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TextValidationError(ValueError):
+    """Raised when text validation fails."""
+
+
+class TextProcessor:
+    """
+    Validates text values using an optional regex defined on a parameter definition.
+      - extracting regex/name/type from a parameter definition (if provided)
+      - compiling regex defensively
+      - validating values (no transformation)
+    """
+
+    def __init__(
+        self,
+        *,
+        parameter: Optional[Any] = None,
+        regex: Optional[str] = None,
+        parameter_name: Optional[str] = None,
+        parameter_type: Optional[str] = None,
+    ) -> None:
+        self._parameter_name = parameter_name
+        self._parameter_type = parameter_type
+        self._pattern_str = regex
+
+        if parameter is not None:
+            self._parameter_name = self._safe_get_attr(parameter, "name", self._parameter_name)
+            self._parameter_type = self._safe_get_attr(parameter, "type", self._parameter_type)
+            self._pattern_str = self._safe_get_attr(parameter, "regex", self._pattern_str)
+
+        self._compiled_regex = self._compile(self._pattern_str)
+
+    @staticmethod
+    def _safe_get_attr(obj: Any, attr: str, default: Any) -> Any:
+        try:
+            return getattr(obj, attr, default)
+        except Exception:
+            return default
+
+    @staticmethod
+    def _compile(pattern: Optional[str]) -> Optional[re.Pattern]:
+        if not pattern:
+            return None
+
+        try:
+            return re.compile(pattern)
+        except re.error as exc:
+            LOGGER.error("Invalid regex pattern: %s", exc)
+            raise TextValidationError(f"Invalid regex pattern: {pattern}") from exc
+
+    def validate(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+
+        if self._parameter_type is not None and self._parameter_type != "text":
+            return value
+
+        if not isinstance(value, str):
+            raise TextValidationError(self._format_error("Value must be a string"))
+
+        if not self._compiled_regex:
+            return value
+
+        try:
+            if self._compiled_regex.search(value) is None:
+                raise TextValidationError(
+                    self._format_error(
+                        f"Value '{value}' does not match regex '{self._pattern_str}'"
+                    )
+                )
+            return value
+        except TextValidationError:
+            raise
+        except Exception as exc:
+            LOGGER.exception("Unexpected validation failure: %s", exc)
+            raise TextValidationError(self._format_error("Unexpected validation failure")) from exc
+
+    def _format_error(self, message: str) -> str:
+        if self._parameter_name:
+            return f"Parameter '{self._parameter_name}': {message}"


### PR DESCRIPTION
Allows limiting the text input by applying a regex, i.e. with a .pum.yaml


```
parameters
  - name: oid_prefix
    type: text
    default: ch000000
    description: Object ID prefix for the creation of STANDARDOID
    regex: ^[\w\d]{8}$
```
