### PR TITLE
feat: support application-only releases without changelog files

### DIFF
--- a/docs/docs/application.md
+++ b/docs/docs/application.md
@@ -15,6 +15,11 @@ There are two types of migration hooks:
 - `drop`: Hooks to drop the application before applying migrations.
 - `create`: Hooks to create the application after applying migrations.
 
+!!! tip
+    If a release only changes the application (no database migration), you can publish it
+    without any SQL changelog by using an `APP_ONLY_RELEASE` marker file.
+    See [application-only releases](getting_started.md#application-only-releases).
+
 ## SQL hooks
 
 Hooks are defined as a list of files or plain SQL code to be executed. For example:

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -40,6 +40,21 @@ Each file contains SQL statements for a single migration step.
 
 Changelog should not try to commit.
 
+### Application-only releases
+
+A release may contain no database migration at all (e.g., only application code changed).
+In that case, create the version directory without any SQL file and add an empty marker file named `APP_ONLY_RELEASE` (this also ensures the directory is tracked in Git):
+
+```
+project/
+└── changelogs/
+    └── 1.0.2/
+        └── APP_ONLY_RELEASE
+```
+
+The version is still recorded in the migration table when installing or upgrading, but no SQL is executed.
+A version directory containing both the marker file and SQL files is invalid.
+
 ### Best Practices
 * Keep each migration atomic—one logical change per file.
 * Never modify a changelog file after it has been applied to any environment.

--- a/pum/changelog.py
+++ b/pum/changelog.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+APP_ONLY_RELEASE_FILE = "APP_ONLY_RELEASE"
+
 
 class Changelog:
     """This class represent a changelog directory.
@@ -52,23 +54,47 @@ class Changelog:
         files.sort()
         return files
 
+    def is_app_only(self) -> bool:
+        """Check if the changelog is an application-only release.
+        An application-only release contains no SQL migration files and is marked
+        by the presence of an ``APP_ONLY_RELEASE`` file in the version directory.
+
+        Returns:
+            bool: True if the changelog directory contains an ``APP_ONLY_RELEASE`` marker file.
+
+        Version Added:
+            1.8.0
+
+        """
+        return (Path(self.dir) / APP_ONLY_RELEASE_FILE).is_file()
+
     def validate(self, parameters: dict | None = None) -> bool:
         """Validate the changelog directory.
         This is done by checking if the directory exists and if it contains at least one SQL file.
+        A changelog without SQL files is valid only if it contains an ``APP_ONLY_RELEASE``
+        marker file, denoting an application-only release without database migrations.
 
         Args:
             parameters: The parameters to pass to the SQL files.
 
         Raises:
-            PumInvalidChangelog: If the changelog directory does not exist or does not contain any SQL files.
+            PumInvalidChangelog: If the changelog directory does not exist or does not contain
+                any SQL files (unless marked as an application-only release).
 
         """
         if not self.dir.is_dir():
             raise PumInvalidChangelog(f"Changelog directory `{self.dir}` does not exist.")
         files = self.files()
-        if not files:
+        if not files and not self.is_app_only():
             raise PumInvalidChangelog(
-                f"Changelog directory `{self.dir}` does not contain any SQL files."
+                f"Changelog directory `{self.dir}` does not contain any SQL files. "
+                f"For an application-only release without database migrations, "
+                f"add an empty `{APP_ONLY_RELEASE_FILE}` file to the directory."
+            )
+        if files and self.is_app_only():
+            raise PumInvalidChangelog(
+                f"Changelog directory `{self.dir}` contains an `{APP_ONLY_RELEASE_FILE}` "
+                f"marker file but also SQL files. Remove the marker file or the SQL files."
             )
         for file in files:
             if not file.is_file():
@@ -121,7 +147,12 @@ class Changelog:
                 The list of changelogs that were executed
 
         """
-        logger.info(f"Applying changelog version {self.version} from {self.dir}")
+        if self.is_app_only():
+            logger.info(
+                f"Recording application-only release version {self.version} from {self.dir}"
+            )
+        else:
+            logger.info(f"Applying changelog version {self.version} from {self.dir}")
 
         parameters_literals = SqlContent.prepare_parameters(parameters)
         files = self.files()

--- a/test/data/app_only_release/changelogs/1.2.3/create_table.sql
+++ b/test/data/app_only_release/changelogs/1.2.3/create_table.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA IF NOT EXISTS pum_test_data;
+
+CREATE TABLE pum_test_data.some_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    created_date DATE DEFAULT CURRENT_DATE,
+    is_active BOOLEAN DEFAULT TRUE,
+    amount NUMERIC(10,2)
+);

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,6 +1,8 @@
 import unittest
+import tempfile
 from pathlib import Path
 
+from pum.changelog import Changelog, APP_ONLY_RELEASE_FILE
 from pum.pum_config import PumConfig
 from pum.exceptions import PumInvalidChangelog
 
@@ -18,6 +20,39 @@ class TestChangelog(unittest.TestCase):
         with self.assertRaises(PumInvalidChangelog):
             for changelog in cfg.changelogs():
                 changelog.validate()
+
+    def test_app_only_release(self) -> None:
+        """Test that a changelog with an APP_ONLY_RELEASE marker and no SQL files is valid."""
+        cfg = PumConfig(
+            Path("test") / "data" / "app_only_release",
+            pum={"module": "test_app_only_release"},
+        )
+        changelogs = cfg.changelogs()
+        self.assertEqual(len(changelogs), 2)
+        self.assertFalse(changelogs[0].is_app_only())
+        self.assertTrue(changelogs[1].is_app_only())
+        self.assertEqual(changelogs[1].files(), [])
+        self.assertTrue(changelogs[1].validate())
+
+    def test_empty_changelog_without_marker(self) -> None:
+        """Test that a changelog without SQL files and without marker is invalid."""
+        with tempfile.TemporaryDirectory() as tmp:
+            version_dir = Path(tmp) / "1.0.0"
+            version_dir.mkdir()
+            with self.assertRaises(PumInvalidChangelog) as ctx:
+                Changelog(version_dir).validate()
+            self.assertIn(APP_ONLY_RELEASE_FILE, str(ctx.exception))
+
+    def test_app_only_release_with_sql_files(self) -> None:
+        """Test that a changelog with both the marker and SQL files is invalid."""
+        with tempfile.TemporaryDirectory() as tmp:
+            version_dir = Path(tmp) / "1.0.0"
+            version_dir.mkdir()
+            (version_dir / APP_ONLY_RELEASE_FILE).touch()
+            (version_dir / "01_something.sql").write_text("SELECT 1;")
+            with self.assertRaises(PumInvalidChangelog) as ctx:
+                Changelog(version_dir).validate()
+            self.assertIn(APP_ONLY_RELEASE_FILE, str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/test/test_upgrader.py
+++ b/test/test_upgrader.py
@@ -481,6 +481,40 @@ class TestUpgrader(unittest.TestCase):
             upgrader.upgrade(connection=conn)
             self.assertEqual(sm.baseline(conn), Version("2.0.0"))
 
+    def test_install_app_only_release(self) -> None:
+        """Test the installation with an app-only release (no SQL files, APP_ONLY_RELEASE marker)."""
+        test_dir = Path("test") / "data" / "app_only_release"
+        cfg = PumConfig(test_dir, pum={"module": "test_app_only_release"})
+        sm = SchemaMigrations(cfg)
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            self.assertFalse(sm.exists(conn))
+            upgrader = Upgrader(config=cfg)
+            upgrader.install(connection=conn)
+            self.assertTrue(sm.exists(conn))
+            self.assertEqual(sm.baseline(conn), Version("1.3.0"))
+            self.assertEqual(sm.migration_details(conn)["version"], "1.3.0")
+            self.assertEqual(sm.migration_details(conn)["changelog_files"], [])
+            self.assertEqual(sm.compare(connection=conn), 0)
+
+    def test_upgrade_app_only_release(self) -> None:
+        """Test upgrading to an app-only release (no SQL files, APP_ONLY_RELEASE marker)."""
+        test_dir = Path("test") / "data" / "app_only_release"
+        cfg = PumConfig(test_dir, pum={"module": "test_app_only_release"})
+        sm = SchemaMigrations(cfg)
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            upgrader = Upgrader(config=cfg)
+            upgrader.install(connection=conn, max_version="1.2.3")
+            self.assertEqual(sm.baseline(conn), Version("1.2.3"))
+            self.assertEqual(sm.compare(connection=conn), -1)
+
+            upgrader.upgrade(connection=conn)
+            self.assertEqual(sm.baseline(conn), Version("1.3.0"))
+            self.assertEqual(sm.compare(connection=conn), 0)
+
+            # Upgrading again should do nothing
+            upgrader.upgrade(connection=conn)
+            self.assertEqual(sm.baseline(conn), Version("1.3.0"))
+
     def test_upgrade_blocked_when_installed_beta_testing_unless_forced(self) -> None:
         """Upgrading a beta-testing installation should be blocked unless forced."""
         test_dir = Path("test") / "data" / "multiple_changelogs"


### PR DESCRIPTION
A release directory containing an APP_ONLY_RELEASE marker file (and no SQL files) is recorded in the migration table without applying any database change, allowing application versions to be released without a corresponding delta.