### PR TITLE
feat: Log pum version in migration table

### DIFF
--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -15,18 +15,12 @@ import psycopg.sql
 
 from .exceptions import PumSchemaMigrationError, PumSchemaMigrationNoBaselineError
 from .sql_content import SqlContent
-from .pum_config import PumConfig
-
+from .pum_config import PumConfig,PUM_VERSION
+ 
 logger = logging.getLogger(__name__)
 
 MIGRATION_TABLE_VERSION = 3  # Current schema version
 MIGRATION_TABLE_NAME = "pum_migrations"
-
-try:
-    PUM_VERSION = packaging.version.Version(version("pum"))
-except PackageNotFoundError:
-    # fallback when running from source (not installed)
-    PUM_VERSION = packaging.version.Version("0.0.0")
 
 
 # TABLE VERSION HISTORY

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -1,3 +1,9 @@
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
 import json
 import logging
 import re
@@ -13,8 +19,15 @@ from .pum_config import PumConfig
 
 logger = logging.getLogger(__name__)
 
-MIGRATION_TABLE_VERSION = 2  # Current schema version
+MIGRATION_TABLE_VERSION = 3  # Current schema version
 MIGRATION_TABLE_NAME = "pum_migrations"
+
+try:
+    PUM_VERSION = packaging.version.Version(version("pum"))
+except PackageNotFoundError:
+    # fallback when running from source (not installed)
+    PUM_VERSION = packaging.version.Version("0.0.0")
+
 
 # TABLE VERSION HISTORY
 #
@@ -24,6 +37,9 @@ MIGRATION_TABLE_NAME = "pum_migrations"
 #
 # Version 2:
 #   Changed migration_table_version type to integer and set module NOT NULL (version 2025.1 => 1, module 'tww')
+#
+# Version 3:
+#   Added column pum_version to manage shift in WRITE rights
 
 
 class SchemaMigrations:
@@ -232,6 +248,7 @@ class SchemaMigrations:
             "version": psycopg.sql.Literal(MIGRATION_TABLE_VERSION),
             "schema": psycopg.sql.Identifier(self.config.config.pum.migration_table_schema),
             "table": self.migration_table_identifier,
+            "pum_version": psycopg.sql.Literal(PUM_VERSION),
         }
 
         create_schema_query = None
@@ -248,12 +265,13 @@ class SchemaMigrations:
             beta_testing boolean NOT NULL DEFAULT false,
             changelog_files text[],
             parameters jsonb,
-            migration_table_version integer NOT NULL DEFAULT {version}
+            migration_table_version integer NOT NULL DEFAULT {version},
+            pum_version varying(50) NOT NULL default {pum_version}
             );
         """
         )
 
-        comment_query = psycopg.sql.SQL("COMMENT ON TABLE {table} IS 'migration_table_version: 2';")
+        comment_query = psycopg.sql.SQL("COMMENT ON TABLE {table} IS 'migration_table_version: 3';")
 
         if create_schema_query:
             SqlContent(create_schema_query).execute(connection, parameters=parameters)
@@ -368,14 +386,16 @@ INSERT INTO {table} (
     beta_testing,
     migration_table_version,
     changelog_files,
-    parameters
+    parameters,
+    pum_version
 ) VALUES (
     {module},
     {version},
     {beta_testing},
     {migration_table_version},
     {changelog_files},
-    {parameters}
+    {parameters},
+    {pum_version}
 );""")
 
         query_parameters = {
@@ -386,6 +406,7 @@ INSERT INTO {table} (
             "migration_table_version": psycopg.sql.Literal(MIGRATION_TABLE_VERSION),
             "changelog_files": psycopg.sql.Literal(changelog_files or []),
             "parameters": psycopg.sql.Literal(json.dumps(parameters or {})),
+            "pum_version": psycopg.sql.Literal(PUM_VERSION),
         }
 
         logger.info(
@@ -479,17 +500,43 @@ INSERT INTO {table} (
                 installed_date,
                 CASE WHEN upgrade_date > installed_date THEN upgrade_date END AS upgrade_date,
                 beta_testing,
-                parameters
+                parameters,
+                pum_version
             FROM (
                 SELECT
-                    module,
-                    (SELECT version FROM {table} ORDER BY version DESC, date_installed DESC LIMIT 1) AS version,
-                    MIN(date_installed) AS installed_date,
-                    MAX(date_installed) AS upgrade_date,
-                    (SELECT beta_testing FROM {table} ORDER BY version DESC, date_installed DESC LIMIT 1) AS beta_testing,
-                    (SELECT parameters FROM {table} ORDER BY version DESC, date_installed DESC LIMIT 1) AS parameters
-                FROM {table}
-                GROUP BY module
+                    t.module,
+                    (
+                        SELECT t2.version
+                        FROM {table} t2
+                        WHERE t2.module = t.module
+                        ORDER BY t2.version DESC, t2.date_installed DESC
+                        LIMIT 1
+                    ) AS version,
+                    MIN(t.date_installed) AS installed_date,
+                    MAX(t.date_installed) AS upgrade_date,
+                    (
+                        SELECT t2.beta_testing
+                        FROM {table} t2
+                        WHERE t2.module = t.module
+                        ORDER BY t2.version DESC, t2.date_installed DESC
+                        LIMIT 1
+                    ) AS beta_testing,
+                    (
+                        SELECT t2.parameters
+                        FROM {table} t2
+                        WHERE t2.module = t.module
+                        ORDER BY t2.version DESC, t2.date_installed DESC
+                        LIMIT 1
+                    ) AS parameters,
+                    (
+                        SELECT COALESCE(to_jsonb(t2) ->> 'pum_version', '0.0.0')
+                        FROM {table} t2
+                        WHERE t2.module = t.module
+                        ORDER BY t2.version DESC, t2.date_installed DESC
+                        LIMIT 1
+                    ) AS pum_version
+                FROM {table} t
+                GROUP BY t.module
             ) sub
             """
         )

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -331,6 +331,17 @@ class SchemaMigrations:
             }
             SqlContent(alter_query).execute(connection, parameters=parameters)
 
+        if table_version < 3:
+            alter_query = psycopg.sql.SQL("""
+                                          ALTER TABLE {table} ADD COLUMN pum_version integer DEFAULT {pum_version};
+                                          """)
+            parameters = {
+                "table": self.migration_table_identifier,
+                "pum_version": psycopg.sql.Literal(PUM_VERSION),
+            }
+            SqlContent(alter_query).execute(connection, parameters=parameters)
+
+
     def set_baseline(
         self,
         connection: psycopg.Connection,

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -1,9 +1,3 @@
-
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
-
 import json
 import logging
 import re
@@ -13,15 +7,15 @@ import packaging.version
 import psycopg
 import psycopg.sql
 
+from ._version import __version__
 from .exceptions import PumSchemaMigrationError, PumSchemaMigrationNoBaselineError
+from .pum_config import PumConfig
 from .sql_content import SqlContent
-from .pum_config import PumConfig,PUM_VERSION
- 
+
 logger = logging.getLogger(__name__)
 
 MIGRATION_TABLE_VERSION = 3  # Current schema version
 MIGRATION_TABLE_NAME = "pum_migrations"
-
 
 # TABLE VERSION HISTORY
 #
@@ -33,7 +27,7 @@ MIGRATION_TABLE_NAME = "pum_migrations"
 #   Changed migration_table_version type to integer and set module NOT NULL (version 2025.1 => 1, module 'tww')
 #
 # Version 3:
-#   Added column pum_version to manage shift in WRITE rights
+#   Added column pum_version recording the pum version used to apply the migration
 
 
 class SchemaMigrations:
@@ -242,7 +236,7 @@ class SchemaMigrations:
             "version": psycopg.sql.Literal(MIGRATION_TABLE_VERSION),
             "schema": psycopg.sql.Identifier(self.config.config.pum.migration_table_schema),
             "table": self.migration_table_identifier,
-            "pum_version": psycopg.sql.Literal(PUM_VERSION),
+            "pum_version": psycopg.sql.Literal(__version__),
         }
 
         create_schema_query = None
@@ -260,12 +254,14 @@ class SchemaMigrations:
             changelog_files text[],
             parameters jsonb,
             migration_table_version integer NOT NULL DEFAULT {version},
-            pum_version varying(50) NOT NULL default {pum_version}
+            pum_version character varying(50) NOT NULL DEFAULT {pum_version}
             );
         """
         )
 
-        comment_query = psycopg.sql.SQL("COMMENT ON TABLE {table} IS 'migration_table_version: 3';")
+        comment_query = psycopg.sql.SQL(
+            f"COMMENT ON TABLE {{table}} IS 'migration_table_version: {MIGRATION_TABLE_VERSION}';"
+        )
 
         if create_schema_query:
             SqlContent(create_schema_query).execute(connection, parameters=parameters)
@@ -332,15 +328,15 @@ class SchemaMigrations:
             SqlContent(alter_query).execute(connection, parameters=parameters)
 
         if table_version < 3:
+            # The pum version used for pre-existing rows is unknown, so the
+            # column is left NULL for them.
             alter_query = psycopg.sql.SQL("""
-                                          ALTER TABLE {table} ADD COLUMN pum_version integer DEFAULT {pum_version};
+                                          ALTER TABLE {table} ADD COLUMN IF NOT EXISTS pum_version character varying(50);
                                           """)
             parameters = {
                 "table": self.migration_table_identifier,
-                "pum_version": psycopg.sql.Literal(PUM_VERSION),
             }
             SqlContent(alter_query).execute(connection, parameters=parameters)
-
 
     def set_baseline(
         self,
@@ -411,7 +407,7 @@ INSERT INTO {table} (
             "migration_table_version": psycopg.sql.Literal(MIGRATION_TABLE_VERSION),
             "changelog_files": psycopg.sql.Literal(changelog_files or []),
             "parameters": psycopg.sql.Literal(json.dumps(parameters or {})),
-            "pum_version": psycopg.sql.Literal(PUM_VERSION),
+            "pum_version": psycopg.sql.Literal(__version__),
         }
 
         logger.info(
@@ -492,11 +488,15 @@ INSERT INTO {table} (
 
         Returns:
             dict: A dict with keys: schema, module, version, installed_date,
-                  upgrade_date (None if never upgraded), beta_testing, parameters.
+                  upgrade_date (None if never upgraded), beta_testing, parameters,
+                  pum_version (the pum version used for the latest migration,
+                  "0.0.0" if unknown).
 
         Raises:
             PumSchemaMigrationError: If the migration table does not exist or has no data.
         """
+        # to_jsonb is used for pum_version so the query also works on migration
+        # tables (version < 3) that lack the pum_version column.
         query = psycopg.sql.SQL(
             """
             SELECT
@@ -562,6 +562,7 @@ INSERT INTO {table} (
                 "upgrade_date": row[3],
                 "beta_testing": row[4],
                 "parameters": row[5],
+                "pum_version": row[6],
             }
 
     def migration_details(self, connection: psycopg.Connection, version: str | None = None) -> dict:

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -316,7 +316,7 @@ class SchemaMigrations:
         logger.info(
             f"Updating migration table {self.migration_table_identifier_str} from version {table_version} to {MIGRATION_TABLE_VERSION}."
         )
-        if table_version == 1:
+        if table_version < 2:
             alter_query = psycopg.sql.SQL("""
                                           ALTER TABLE {table} ALTER COLUMN migration_table_version ALTER TYPE integer SET DEFAULT {version} USING 1;
                                           ALTER TABLE {table} ALTER COLUMN module SET NOT NULL USING 'tww';

--- a/pum/schema_migrations.py
+++ b/pum/schema_migrations.py
@@ -338,6 +338,14 @@ class SchemaMigrations:
             }
             SqlContent(alter_query).execute(connection, parameters=parameters)
 
+        if table_version < MIGRATION_TABLE_VERSION:
+            comment_query = psycopg.sql.SQL(
+                f"COMMENT ON TABLE {{table}} IS 'migration_table_version: {MIGRATION_TABLE_VERSION}';"
+            )
+            SqlContent(comment_query).execute(
+                connection, parameters={"table": self.migration_table_identifier}
+            )
+
     def set_baseline(
         self,
         connection: psycopg.Connection,

--- a/test/test_schema_migrations.py
+++ b/test/test_schema_migrations.py
@@ -6,6 +6,7 @@ from packaging.version import Version
 
 import psycopg
 
+from pum import __version__
 from pum.pum_config import PumConfig
 from pum.exceptions import PumException
 from pum.schema_migrations import SchemaMigrations
@@ -128,7 +129,8 @@ class TestSchemaMigrations(unittest.TestCase):
                 sm.compare(connection=conn)
 
             self.assertIn(
-                "Changelog for version 9.9.9 not found in the source", str(context.exception)
+                "Changelog for version 9.9.9 not found in the source",
+                str(context.exception),
             )
 
     def test_schemas_with_migrations(self) -> None:
@@ -226,7 +228,10 @@ class TestSchemaMigrations(unittest.TestCase):
         cfg1 = PumConfig(test_dir, pum={"module": "module_a", "migration_table_schema": "public"})
         cfg2 = PumConfig(
             test_dir,
-            pum={"module": "module_b", "migration_table_schema": "pum_custom_migrations_schema"},
+            pum={
+                "module": "module_b",
+                "migration_table_schema": "pum_custom_migrations_schema",
+            },
         )
         sm1 = SchemaMigrations(cfg1)
         sm2 = SchemaMigrations(cfg2)
@@ -286,6 +291,38 @@ class TestSchemaMigrations(unittest.TestCase):
             self.assertIsNone(summary["upgrade_date"])
             self.assertFalse(summary["beta_testing"])
             self.assertIn("SRID", summary["parameters"])
+            self.assertEqual(summary["pum_version"], __version__)
+
+            details = sm.migration_details(conn)
+            self.assertEqual(details["pum_version"], __version__)
+
+    def test_update_migration_table_schema_from_v2(self) -> None:
+        """Test upgrading a version 2 migration table adds the pum_version column."""
+        test_dir = Path("test") / "data" / "single_changelog"
+        cfg = PumConfig(test_dir, pum={"module": "test_module"})
+        sm = SchemaMigrations(cfg)
+
+        with psycopg.connect(f"service={self.pg_service}") as conn:
+            sm.create(connection=conn)
+            sm.set_baseline(connection=conn, version="1.2.3")
+            # Simulate a version 2 migration table (without pum_version column)
+            conn.execute("ALTER TABLE public.pum_migrations DROP COLUMN pum_version;")
+            conn.execute("UPDATE public.pum_migrations SET migration_table_version = 2;")
+
+            # Old rows have an unknown pum version, reported as 0.0.0
+            summary = sm.migration_summary(conn)
+            self.assertEqual(summary["pum_version"], "0.0.0")
+
+            sm.update_migration_table_schema(conn)
+            # The column is added and NULL for pre-existing rows
+            details = sm.migration_details(conn)
+            self.assertIn("pum_version", details)
+            self.assertIsNone(details["pum_version"])
+
+            # A new baseline records the current pum version
+            sm.set_baseline(connection=conn, version="1.2.4")
+            details = sm.migration_details(conn)
+            self.assertEqual(details["pum_version"], __version__)
 
     def test_migration_summary_after_upgrade(self) -> None:
         """Test migration_summary shows upgrade_date after a second baseline."""

--- a/test/test_schema_migrations.py
+++ b/test/test_schema_migrations.py
@@ -9,7 +9,7 @@ import psycopg
 from pum import __version__
 from pum.pum_config import PumConfig
 from pum.exceptions import PumException
-from pum.schema_migrations import SchemaMigrations
+from pum.schema_migrations import MIGRATION_TABLE_VERSION, SchemaMigrations
 from pum.upgrader import Upgrader
 
 
@@ -308,6 +308,7 @@ class TestSchemaMigrations(unittest.TestCase):
             # Simulate a version 2 migration table (without pum_version column)
             conn.execute("ALTER TABLE public.pum_migrations DROP COLUMN pum_version;")
             conn.execute("UPDATE public.pum_migrations SET migration_table_version = 2;")
+            conn.execute("COMMENT ON TABLE public.pum_migrations IS 'migration_table_version: 2';")
 
             # Old rows have an unknown pum version, reported as 0.0.0
             summary = sm.migration_summary(conn)
@@ -318,6 +319,12 @@ class TestSchemaMigrations(unittest.TestCase):
             details = sm.migration_details(conn)
             self.assertIn("pum_version", details)
             self.assertIsNone(details["pum_version"])
+
+            # The table comment is updated to the current migration table version
+            comment = conn.execute(
+                "SELECT obj_description('public.pum_migrations'::regclass, 'pg_class');"
+            ).fetchone()[0]
+            self.assertEqual(comment, f"migration_table_version: {MIGRATION_TABLE_VERSION}")
 
             # A new baseline records the current pum version
             sm.set_baseline(connection=conn, version="1.2.4")


### PR DESCRIPTION
Adapt migration table to hold the pum version which was ran to process the changelogs.